### PR TITLE
allow to parse error responses from fetch API

### DIFF
--- a/api.md
+++ b/api.md
@@ -170,6 +170,7 @@ Describes an effect that will send an HTTP request using [`fetch`](https://devel
 | props.url | <code>string</code> | URL for sending HTTP request |
 | props.options | <code>object</code> | same [options as `fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#Parameters) |
 | props.response | <code>string</code> | Specify which method to use on the response body, defaults to `"json"`, other [supported methods](https://developer.mozilla.org/en-US/docs/Web/API/Response#Methods) include `"text"` |
+| props.errorResponse | <code>string</code> | Specify which method to use on the error response body, defaults to raw response with no parsing, other [supported methods](https://developer.mozilla.org/en-US/docs/Web/API/Response#Methods) include `"text"` |
 | props.action | <code>\*</code> | Action to call with the results of a successful HTTP response |
 | props.error | <code>\*</code> | Action to call if there is a problem making the request or a not-ok HTTP response, defaults to the same action defined for success |
 

--- a/src/fx/Http.js
+++ b/src/fx/Http.js
@@ -15,6 +15,12 @@ function httpEffect(dispatch, props) {
       dispatch(props.action, result)
     })
     .catch(function(error) {
+      if (props.errorResponse) {
+        return error[props.errorResponse]()
+      }
+      return error
+    })
+    .then(function(error) {
       dispatch(props.error, error)
     })
 }
@@ -27,6 +33,7 @@ function httpEffect(dispatch, props) {
  * @param {string} props.url - URL for sending HTTP request
  * @param {object} props.options - same [options as `fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#Parameters)
  * @param {string} props.response - Specify which method to use on the response body, defaults to `"json"`, other [supported methods](https://developer.mozilla.org/en-US/docs/Web/API/Response#Methods) include `"text"`
+ * @param {string} props.errorResponse - Specify which method to use on the error response body, defaults to raw response with no parsing, other [supported methods](https://developer.mozilla.org/en-US/docs/Web/API/Response#Methods) include `"text"`
  * @param {*} props.action - Action to call with the results of a successful HTTP response
  * @param {*} props.error - Action to call if there is a problem making the request or a not-ok HTTP response, defaults to the same action defined for success
  * @example

--- a/test/fx/Http.test.js
+++ b/test/fx/Http.test.js
@@ -139,4 +139,27 @@ describe("Http effect", () => {
       done()
     })
   })
+  it("should allow response parser on error", done => {
+    const testUrl = "https://example.com/hello"
+    const response = {
+      ok: false,
+      json() {
+        return Promise.resolve({ msg: "Failed" })
+      }
+    }
+    global.fetch = (url, options) => {
+      expect(url).toBe(testUrl)
+      expect(options).toEqual({})
+      return Promise.resolve(response)
+    }
+    const action = jest.fn()
+    const httpFx = Http({ url: testUrl, errorResponse: "json", action })
+    const { dispatch } = runFx(httpFx)
+
+    process.nextTick(() => {
+      expect(dispatch).toBeCalledWith(action, { msg: "Failed" })
+      delete global.fetch
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This PR introduces errorResponse parser so that we don't need to parse e.g. JSON errors in the user space.