### PR TITLE
add missing .js to utils import path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
+  - "13"
 
 env:
   - NODE_ENV=development

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - NODE_ENV=development
 
 before_install:
-  - npm i -g npx
+  - which npx || npm i -g npx
 
 cache:
   directories:

--- a/src/fx/Time.js
+++ b/src/fx/Time.js
@@ -1,4 +1,4 @@
-import { makeDispatchTime } from "../utils"
+import { makeDispatchTime } from "../utils.js"
 
 function nowEffect(dispatch, props) {
   makeDispatchTime(dispatch, props)()

--- a/src/subs/History.js
+++ b/src/subs/History.js
@@ -1,4 +1,4 @@
-import { makeRemoveListener } from "../utils"
+import { makeRemoveListener } from "../utils.js"
 
 function historyPopEffect(dispatch, props) {
   return makeRemoveListener(window, dispatch, props.action, "popstate")

--- a/src/subs/Time.js
+++ b/src/subs/Time.js
@@ -1,4 +1,4 @@
-import { makeDispatchTime } from "../utils"
+import { makeDispatchTime } from "../utils.js"
 
 function intervalEffect(dispatch, props) {
   var dispatchTime = makeDispatchTime(dispatch, props)


### PR DESCRIPTION
github serves 404 for the imports that end with utils instead of utils.js,

this breaks
https://tetris-rbizvjgqbj.now.sh/
issue:
https://github.com/lukejacksonn/tetris/issues/4