### PR TITLE
Add onopen / onclose hooks to WebSocketListen

### DIFF
--- a/api.md
+++ b/api.md
@@ -699,6 +699,8 @@ Describes an effect that will open a [`WebSocket`](https://developer.mozilla.org
 | props.protocols | <code>string</code> \| <code>Array.&lt;string&gt;</code> | Either a single protocol string or an array of protocol strings. These strings are used to indicate sub-protocols, so that a single server can implement multiple WebSocket sub-protocols (for example, you might want one server to be able to handle different types of interactions depending on the specified `protocol`). If you don't specify a protocol string, an empty string is assumed. |
 | props.action | <code>\*</code> | action to call with new incoming messages |
 | props.error | <code>\*</code> | action to call if an error occurs |
+| props.open | <code>\*</code> | action to call when the socket is opened |
+| props.close | <code>\*</code> | action to call when the socket is closed |
 
 **Example**  
 ```js

--- a/src/subs/WebSocket.js
+++ b/src/subs/WebSocket.js
@@ -23,12 +23,39 @@ function webSocketListenEffect(dispatch, props) {
     )
     connection.listeners.push(removeError)
   }
+  var removeOpen
+  if (props.open) {
+    removeOpen = makeRemoveListener(
+      connection.socket,
+      dispatch,
+      props.open,
+      "open"
+    )
+    connection.listeners.push(removeOpen)
+  }
+  var removeClose
+  if (props.close) {
+    removeClose = makeRemoveListener(
+      connection.socket,
+      dispatch,
+      props.close,
+      "close"
+    )
+    connection.listeners.push(removeClose)
+  }
 
   return function() {
     removeListen && removeListen()
     removeError && removeError()
+    removeOpen && removeOpen()
+    removeClose && removeClose()
     connection.listeners = connection.listeners.filter(function(listener) {
-      return listener !== removeListen && listener !== removeError
+      return (
+        listener !== removeListen &&
+        listener !== removeError &&
+        listener !== removeOpen &&
+        listener !== removeClose
+      )
     })
     if (connection.listeners.length === 0) {
       closeWebSocket(props)
@@ -45,6 +72,8 @@ function webSocketListenEffect(dispatch, props) {
  * @param {string | string[]} props.protocols - Either a single protocol string or an array of protocol strings. These strings are used to indicate sub-protocols, so that a single server can implement multiple WebSocket sub-protocols (for example, you might want one server to be able to handle different types of interactions depending on the specified `protocol`). If you don't specify a protocol string, an empty string is assumed.
  * @param {*} props.action - action to call with new incoming messages
  * @param {*} props.error - action to call if an error occurs
+ * @param {*} props.open - action to call when the socket is opened
+ * @param {*} props.close - action to call when the socket is closed
  * @example
  * import { WebSocketListen } from "hyperapp-fx"
  *

--- a/test/subs/WebSocketClient.test.js
+++ b/test/subs/WebSocketClient.test.js
@@ -82,13 +82,26 @@ describe("WebSocketListen subscription", () => {
     )
   })
   it("should reuse an existing WebSocket and not close the socket if another socket is already listening", () => {
+    const onopen = jest.fn()
+    const onclose = jest.fn()
+
     const listen1 = jest.fn()
-    const webSocketFx1 = WebSocketListen({ url, listen: listen1 })
+    const webSocketFx1 = WebSocketListen({
+      url,
+      listen: listen1,
+      open: onopen,
+      close: onclose
+    })
     const { unsubscribe: unsubscribe1 } = runFx(webSocketFx1)
 
     WebSocket.mockReset()
     const listen2 = jest.fn()
-    const webSocketFx2 = WebSocketListen({ url, listen: listen2 })
+    const webSocketFx2 = WebSocketListen({
+      url,
+      listen: listen2,
+      open: onopen,
+      close: onclose
+    })
     const { unsubscribe: unsubscribe2 } = runFx(webSocketFx2)
     expect(WebSocket).not.toBeCalled()
 


### PR DESCRIPTION
My websocket server is unreliable and my network is slow - I want to know (and react to) the socket opening, not just assume "the Subscription exists, so it must be working"