### PR TITLE
Allow custom WebSocket constructor

### DIFF
--- a/api.md
+++ b/api.md
@@ -699,6 +699,7 @@ Describes an effect that will open a [`WebSocket`](https://developer.mozilla.org
 | props.protocols | <code>string</code> \| <code>Array.&lt;string&gt;</code> | Either a single protocol string or an array of protocol strings. These strings are used to indicate sub-protocols, so that a single server can implement multiple WebSocket sub-protocols (for example, you might want one server to be able to handle different types of interactions depending on the specified `protocol`). If you don't specify a protocol string, an empty string is assumed. |
 | props.action | <code>\*</code> | action to call with new incoming messages |
 | props.error | <code>\*</code> | action to call if an error occurs |
+| props.ws_constructor | <code>\*</code> | an optional replacement for the WebSocket constructor |
 
 **Example**  
 ```js

--- a/src/subs/WebSocket.js
+++ b/src/subs/WebSocket.js
@@ -45,6 +45,7 @@ function webSocketListenEffect(dispatch, props) {
  * @param {string | string[]} props.protocols - Either a single protocol string or an array of protocol strings. These strings are used to indicate sub-protocols, so that a single server can implement multiple WebSocket sub-protocols (for example, you might want one server to be able to handle different types of interactions depending on the specified `protocol`). If you don't specify a protocol string, an empty string is assumed.
  * @param {*} props.action - action to call with new incoming messages
  * @param {*} props.error - action to call if an error occurs
+ * @param {*} props.ws_constructor - an optional replacement for the WebSocket constructor
  * @example
  * import { WebSocketListen } from "hyperapp-fx"
  *

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,8 +25,11 @@ var webSocketConnections = {}
 export function getOpenWebSocket(props) {
   var connection = webSocketConnections[props.url]
   if (!connection) {
+    var socket = props.ws_constructor
+      ? new props.ws_constructor(props.url, props.protocols)
+      : new WebSocket(props.url, props.protocols)
     connection = {
-      socket: new WebSocket(props.url, props.protocols),
+      socket: socket,
       listeners: []
     }
     webSocketConnections[props.url] = connection


### PR DESCRIPTION
As things are now, I don't see any way to cope with a WebSocketListen connection getting disconnected. I'd like to use ReconnectingWebSocket as a drop-in replcement for WebSocket, and this seems like the least-ugly way to do that.