### PR TITLE
Enable CI for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI was enabled for pushes (when the repo owner pushes to their own repo), but not pull requests - so CI was happening on my copy of the repo[1], but it wasn't happening when I made a pull request to upstream [2]

[1] https://github.com/shish/hyperapp-fx/actions
[2] https://github.com/okwolf/hyperapp-fx/pull/51